### PR TITLE
`AV-56565 Docsearch - handle results from the new Algolia docsearch

### DIFF
--- a/src/js/vendor/docsearch.bundle.js
+++ b/src/js/vendor/docsearch.bundle.js
@@ -299,6 +299,7 @@
         return accum
       }, {})
     )
+      .filter((a) => a[1].title)
       .sort(function (a, b) {
         return a[1].title.replace(/^\./, '').localeCompare(b[1].title.replace(/^\./, ''))
       })
@@ -321,20 +322,11 @@
   }
 
   function extractComponentVersionInfo (hit) {
-    var name, title, version
-    var componentVersion = hit.component_version
-    if (componentVersion) {
-      componentVersion = (Array.isArray(componentVersion) ? componentVersion[0] : componentVersion).split('@')
-      name = componentVersion[0]
-      version = componentVersion[1]
-      title = hit.component_title
-    } else {
-      name = hit.component
-      componentVersion = (hit.hierarchy.lvl0 || name).split(/ (?=\d+(?:\.|$))/)
-      title = componentVersion[0]
-      version = componentVersion[1]
+    return {
+      name: hit.component,
+      version: hit.cversion,
+      title: hit.component_title || hit.component || '',
     }
-    return { name: name, version: version, title: title }
   }
 
   function renderFilters (components, filters) {

--- a/src/partials/crumbs-meta.hbs
+++ b/src/partials/crumbs-meta.hbs
@@ -5,4 +5,4 @@ Logic extracted from crumbs.hbs --}}
     {{{page.component.title}}}
 {{~/unless~}}
 {{~/unless~}}
-{{~#each page.breadcrumbs}} / {{{./content}}}{{~/each}}
+{{~#each page.breadcrumbs}} › {{{./content}}}{{~/each}}


### PR DESCRIPTION
The new Algolia docsearch is hosted on https://docsearch.algolia.com/ and uses the Algolia crawler infrastructure.

While it's similar to "Legacy Docsearch v2" which we run on AWS EC2, it doesn't seem to return the records in exactly the format that the client .js library was expecting.
(This might be my bad for misconfiguring it? Either way, we have to handle the results arriving in an unexpected shape which:
1) broke the JS entirely
2) or caused it to show bad/incomplete results )

This commit:

* Fix filter of records with no title

* simplifies the Component Version parsing (e.g. "java-sdk", 3.1).
I didn't really understand the existing logic, and in the meantime, our UI is exporting the data in more easily parseable structures.
So, though this doesn't look like a like-for-like translation, I *think* we'll retain the same features...

* Change slash to right chevron, as requested by Website team (to be consistent with how the other index sources are showing breadcrumbs)

Uses U+203A Single Right-Pointing Angle Quotation Mark
(instead of `>`, partly to avoid escaping it in HTML/meta tag...)